### PR TITLE
Fix Float to Double type conversion in VertexAIClientImpl

### DIFF
--- a/app/src/main/java/dev/aurakai/auraframefx/viewmodel/ConferenceRoomViewModel.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/viewmodel/ConferenceRoomViewModel.kt
@@ -156,7 +156,7 @@ class ConferenceRoomViewModel @Inject constructor(
                     }
 
                     AgentType.CLAUDE -> flow {
-                        emit(claudeService.processRequest(request, context).first())
+                        emit(claudeService.processRequest(request, context))
                     }
 
                     AgentType.CASCADE -> flow {
@@ -182,7 +182,7 @@ class ConferenceRoomViewModel @Inject constructor(
 
                     AgentType.METAINSTRUCT -> flow {
                         // MetaInstruct for self-modification and code evolution
-                        emit(metaInstructService.processRequest(request, context).first())
+                        emit(metaInstructService.processRequest(request, context))
                     }
 
                     AgentType.GENESIS -> {


### PR DESCRIPTION
### **User description**
Remove erroneous .first() calls from claudeService and metaInstructService processRequest invocations. These services return AgentResponse directly, not Flow<AgentResponse>, so .first() was causing receiver type mismatch compilation errors.

Fixed at lines 159 and 185 in ConferenceRoomViewModel.kt.


___

### **PR Type**
Bug fix


___

### **Description**
- Remove erroneous `.first()` calls from `claudeService` and `metaInstructService`

- These services return `AgentResponse` directly, not `Flow<AgentResponse>`

- Fixes receiver type mismatch compilation errors in two locations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["claudeService.processRequest"] -->|returns AgentResponse| B["emit directly"]
  C["metaInstructService.processRequest"] -->|returns AgentResponse| D["emit directly"]
  E["Removed .first() calls"] -->|fixes type mismatch| F["Compilation succeeds"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ConferenceRoomViewModel.kt</strong><dd><code>Remove incorrect .first() calls from agent services</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/src/main/java/dev/aurakai/auraframefx/viewmodel/ConferenceRoomViewModel.kt

<ul><li>Removed <code>.first()</code> call from <code>claudeService.processRequest()</code> invocation <br>at line 159<br> <li> Removed <code>.first()</code> call from <code>metaInstructService.processRequest()</code> <br>invocation at line 185<br> <li> Both services return <code>AgentResponse</code> directly, not <code>Flow<AgentResponse></code><br> <li> Fixes type mismatch compilation errors in agent type handling</ul>


</details>


  </td>
  <td><a href="https://github.com/AuraFrameFxDev/ReGenesis/pull/32/files#diff-9609ca2c12d25479138993bd8bfce8b25c8c57a40bd825f38592029012a017f0">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

